### PR TITLE
Migration for PostgreSQL Deployment to OpenTofu Modules for an SQL Database Solution

### DIFF
--- a/modules/cnpg/certificates.tf
+++ b/modules/cnpg/certificates.tf
@@ -1,0 +1,410 @@
+// Fetch MinIO Certificate Authority for PITR Backups
+resource "kubernetes_secret" "minio_certificate_authority" {
+  metadata {
+    name      = var.minio_certificate_authority
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflects" : "${var.minio_namespace}/${var.minio_certificate_authority}"
+    }
+  }
+
+  data = {
+    "tls.crt" = ""
+    "tls.key" = ""
+    "ca.crt"  = ""
+  }
+
+  type = "kubernetes.io/tls"
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+# --------------- POSTGRESQL SERVER CERTIFICATES CONFIGURATION --------------- #
+// Certificate Authority to be used with PostgreSQL Server
+resource "kubernetes_manifest" "server_certificate_authority" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.server_certificate_authority_name
+      "namespace" = var.namespace
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate-authority"
+      }
+    }
+    "spec" = {
+      "isCA" = true
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = ["PostgreSQL"]
+      }
+      "commonName" = var.server_certificate_authority_name
+      "secretName" = var.server_certificate_authority_name
+      "secretTemplate" = {
+        "annotations" = {
+          "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+          "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = length(var.clients) == 0 ? "keycloak" : "keycloak,${join(",", local.replication_namespaces)}"
+        }
+      }
+      "duration" = "70128h"
+      "privateKey" = {
+        "algorithm" = "ECDSA"
+        "size"      = 256
+      }
+      "issuerRef" = {
+        "name"  = "${var.cluster_issuer_name}"
+        "kind"  = "ClusterIssuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Issuer to be used with PostgreSQL Server
+resource "kubernetes_manifest" "server_issuer" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Issuer"
+    "metadata" = {
+      "name"      = var.server_issuer_name
+      "namespace" = "${var.namespace}"
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "issuer"
+      }
+    }
+    "spec" = {
+      "ca" = {
+        "secretName" = kubernetes_manifest.server_certificate_authority.manifest.spec.secretName
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Certificate for PostgreSQL Server
+resource "kubernetes_manifest" "server_certificate" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.server_certificate_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate"
+      }
+    }
+    "spec" = {
+      "usages" : ["server auth"]
+      "dnsNames" = [
+        "postgresql-cluster-rw",
+        "postgresql-cluster-rw.${kubernetes_namespace.namespace.metadata[0].name}",
+        "postgresql-cluster-rw.${kubernetes_namespace.namespace.metadata[0].name}.svc",
+        "postgresql-cluster-r",
+        "postgresql-cluster-r.${kubernetes_namespace.namespace.metadata[0].name}",
+        "postgresql-cluster-r.${kubernetes_namespace.namespace.metadata[0].name}.svc",
+        "postgresql-cluster-ro",
+        "postgresql-cluster-ro.${kubernetes_namespace.namespace.metadata[0].name}",
+        "postgresql-cluster-ro.${kubernetes_namespace.namespace.metadata[0].name}.svc"
+      ]
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = ["postgres"]
+      }
+      "secretName" = var.server_certificate_name
+      "issuerRef" = {
+        "name" = kubernetes_manifest.server_issuer.manifest.metadata.name
+      }
+    }
+  }
+
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+# --------------- POSTGRESQL CLIENT CERTIFICATES CONFIGURATION --------------- #
+// Certificate Authority to be used with PostgreSQL Client
+resource "kubernetes_manifest" "client_certificate_authority" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.client_certificate_authority_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate-authority"
+      }
+    }
+    "spec" = {
+      "isCA" = true
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = ["PostgreSQL"]
+      }
+      "commonName" = var.client_certificate_authority_name
+      "secretName" = var.client_certificate_authority_name
+      "duration"   = "70128h"
+      "privateKey" = {
+        "algorithm" = "ECDSA"
+        "size"      = 256
+      }
+      "issuerRef" = {
+        "name"  = "${var.cluster_issuer_name}"
+        "kind"  = "ClusterIssuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Issuer to be used with PostgreSQL Client
+resource "kubernetes_manifest" "client_issuer" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Issuer"
+    "metadata" = {
+      "name"      = var.client_issuer_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "issuer"
+      }
+    }
+    "spec" = {
+      "ca" = {
+        "secretName" = kubernetes_manifest.client_certificate_authority.manifest.spec.secretName
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Certificate for Streaming Replica
+resource "kubernetes_manifest" "client_streaming_replica_certificate" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.client_streaming_replica_certificate_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate"
+      }
+    }
+    "spec" = {
+      "usages" : ["client auth"]
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = ["PostgreSQL"]
+      }
+      "commonName" = "streaming_replica"
+      "secretName" = var.client_streaming_replica_certificate_name
+      "issuerRef" = {
+        "name" = kubernetes_manifest.client_issuer.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Certificate for Keycloak User
+resource "kubernetes_manifest" "client_keycloak_certificate" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = "postgresql-keycloak-client-certificate"
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate"
+      }
+    }
+    "spec" = {
+      "usages" : ["client auth"]
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = ["PostgreSQL"]
+      }
+      "commonName" = "keycloak"
+      "secretName" = "postgresql-keycloak-client-certificate"
+      "secretTemplate" = {
+        "annotations" = {
+          "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+          "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "keycloak"
+        }
+      }
+      "additionalOutputFormats" = [
+        {
+          "type" : "DER"
+        }
+      ]
+      "privateKey" = {
+        "encoding" = "PKCS8"
+      }
+      "issuerRef" = {
+        "name" = kubernetes_manifest.client_issuer.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Certificates for all clients
+resource "kubernetes_manifest" "client_certificates" {
+  count = length(var.clients)
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = "postgresql-${var.clients[count.index].user}-client-certificate"
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate"
+      }
+    }
+    "spec" = {
+      "usages" : ["client auth"]
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = ["PostgreSQL"]
+      }
+      "commonName" = var.clients[count.index].user
+      "secretName" = "postgresql-${var.clients[count.index].user}-client-certificate"
+      "secretTemplate" = {
+        "annotations" = {
+          "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+          "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = var.clients[count.index].namespace
+        }
+      }
+      "additionalOutputFormats" = var.clients[count.index].derRequired ? [
+        {
+          "type" : "DER"
+        }
+      ] : []
+      "privateKey" = {
+        "encoding" = var.clients[count.index].privateKeyEncoding
+      }
+      "issuerRef" = {
+        "name" = kubernetes_manifest.client_issuer.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}

--- a/modules/cnpg/cluster.tf
+++ b/modules/cnpg/cluster.tf
@@ -1,0 +1,123 @@
+// CloudNative PG Cluster
+resource "kubernetes_manifest" "cluster" {
+  manifest = {
+    "apiVersion" = "postgresql.cnpg.io/v1"
+    "kind"       = "Cluster"
+    "metadata" = {
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "cluster"
+      }
+      "name"      = var.cluster_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+    }
+    "spec" = {
+      "backup" = {
+        "barmanObjectStore" = {
+          "data" = {
+            "additionalCommandArgs" = [
+              "--min-chunk-size=5MB",
+              "--read-timeout=60",
+              "-vv",
+            ]
+          }
+          "destinationPath" = "s3://${var.backup_bucket_name}/"
+          "endpointCA" = {
+            "key"  = "ca.crt"
+            "name" = kubernetes_secret.minio_certificate_authority.metadata[0].name
+          }
+          "endpointURL" = "https://minio-hl.${var.minio_namespace}.svc.cluster.local:9000"
+          "s3Credentials" = {
+            "accessKeyId" = {
+              "key"  = "CONSOLE_ACCESS_KEY"
+              "name" = kubernetes_secret.postgres_user_minio_configuration.metadata[0].name
+            }
+            "secretAccessKey" = {
+              "key"  = "CONSOLE_SECRET_KEY"
+              "name" = kubernetes_secret.postgres_user_minio_configuration.metadata[0].name
+            }
+          }
+          "wal" = {
+            "compression" = "gzip"
+          }
+        }
+        "volumeSnapshot" = {
+          "className" = "csi-hostpath-snapclass"
+        }
+      }
+      "description"           = "PostgreSQL Cluster for storing relational data"
+      "enableSuperuserAccess" = true
+      "imageName"             = "ghcr.io/cloudnative-pg/postgresql:16.2"
+      "instances"             = 2
+      "managed" = {
+        "roles" = concat([
+          {
+            "bypassrls"       = false
+            "comment"         = "keycloak user for postgresql"
+            "connectionLimit" = -1
+            "createdb"        = true
+            "createrole"      = true
+            "ensure"          = "present"
+            "inherit"         = true
+            "login"           = true
+            "name"            = "keycloak"
+            "passwordSecret" = {
+              "name" = kubernetes_secret.keycloak_database_credentials.metadata[0].name
+            }
+            "replication" = false
+            "superuser"   = false
+          },
+        ], local.managed_roles)
+      }
+      "primaryUpdateStrategy" = "unsupervised"
+      "resources" = {
+        "limits" = {
+          "cpu"    = "500m"
+          "memory" = "1Gi"
+        }
+        "requests" = {
+          "cpu"    = "500m"
+          "memory" = "1Gi"
+        }
+      }
+      "startDelay" = 300
+      "storage" = {
+        "pvcTemplate" = {
+          "accessModes" = [
+            "ReadWriteOnce",
+          ]
+          "resources" = {
+            "requests" = {
+              "storage" = "1Gi"
+            }
+          }
+          "storageClassName" = "local-path"
+          "volumeMode"       = "Filesystem"
+        }
+        "size" = "5Gi"
+      }
+      "certificates" = {
+        "serverTLSSecret"      = kubernetes_manifest.server_certificate.manifest.spec.secretName
+        "serverCASecret"       = kubernetes_manifest.server_certificate_authority.manifest.spec.secretName
+        "clientCASecret"       = kubernetes_manifest.client_certificate_authority.manifest.spec.secretName
+        "replicationTLSSecret" = kubernetes_manifest.client_streaming_replica_certificate.manifest.spec.secretName
+      }
+    }
+  }
+
+  // Fields to ignore changes for
+  computed_fields = ["spec.managed.roles[0].replication", "spec.managed.roles[0].superuser", "spec.managed.roles[0].bypassrls", "spec.managed.roles[1].bypassrls", "spec.managed.roles[1].superuser", "spec.managed.roles[1].replication"]
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
+}

--- a/modules/cnpg/database.tf
+++ b/modules/cnpg/database.tf
@@ -1,0 +1,74 @@
+// Database Configuration for Keycloak
+resource "kubernetes_manifest" "keycloak_database" {
+  manifest = {
+    "apiVersion" : "postgresql.cnpg.io/v1"
+    "kind" : "Database"
+    "metadata" = {
+      "name"      = "keycloak"
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "cluster"
+      }
+    }
+
+    "spec" = {
+      "databaseReclaimPolicy" : "delete"
+      "name" : "keycloak"
+      "owner" : "keycloak"
+      "cluster" = {
+        "name" = kubernetes_manifest.cluster.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    fields = {
+      "status.applied" = "true"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Database Configuration for all clients
+resource "kubernetes_manifest" "databases" {
+  count = length(var.clients)
+  manifest = {
+    "apiVersion" : "postgresql.cnpg.io/v1"
+    "kind" : "Database"
+    "metadata" = {
+      "name"      = var.clients[count.index].database
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "cluster"
+      }
+    }
+
+    "spec" = {
+      "databaseReclaimPolicy" : "delete"
+      "name" : var.clients[count.index].database
+      "owner" : var.clients[count.index].user
+      "cluster" = {
+        "name" = kubernetes_manifest.cluster.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    fields = {
+      "status.applied" = "true"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}

--- a/modules/cnpg/locals.tf
+++ b/modules/cnpg/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  replication_namespaces = [for config in var.clients : config.namespace]
+  managed_roles = [for secret in kubernetes_secret.client_database_credentials : {
+    "bypassrls"       = false
+    "comment"         = "${secret.data.username} user for postgresql"
+    "connectionLimit" = -1
+    "createdb"        = true
+    "createrole"      = true
+    "ensure"          = "present"
+    "inherit"         = true
+    "login"           = true
+    "name"            = secret.data.username
+    "passwordSecret" = {
+      "name" = secret.metadata[0].name
+    }
+    "replication" = false
+    "superuser"   = false
+  }]
+}

--- a/modules/cnpg/namespace.tf
+++ b/modules/cnpg/namespace.tf
@@ -1,0 +1,10 @@
+// Namespace configuration for PostgreSQL Database
+resource "kubernetes_namespace" "namespace" {
+  metadata {
+    name = var.namespace
+    labels = {
+      app       = var.app_name
+      component = "namespace"
+    }
+  }
+}

--- a/modules/cnpg/secrets.tf
+++ b/modules/cnpg/secrets.tf
@@ -1,0 +1,97 @@
+// MinIO Credentials for storing PostgreSQL PITR Backups
+resource "kubernetes_secret" "postgres_user_minio_configuration" {
+  metadata {
+    name      = "minio-${var.postgres_user_minio_configuration}"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflects" = "${var.minio_namespace}/${var.postgres_user_minio_configuration}"
+    }
+  }
+
+  data = {
+    CONSOLE_ACCESS_KEY = ""
+    CONSOLE_SECRET_KEY = ""
+  }
+
+  type = "Opaque"
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+// Database credentials configuration for Keycloak
+resource "random_password" "keycloak_password" {
+  length           = 20
+  lower            = true
+  numeric          = true
+  special          = true
+  override_special = "-_*/"
+  min_special      = 3
+}
+
+resource "kubernetes_secret" "keycloak_database_credentials" {
+  metadata {
+    name      = "credentials-keycloak"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "keycloak"
+    }
+  }
+
+  data = {
+    "username" = "keycloak"
+    "password" = random_password.keycloak_password.result
+  }
+
+  type = "kubernetes.io/basic-auth"
+}
+
+// Database credentials configuration for all clients
+resource "random_password" "client_password" {
+  count            = length(var.clients)
+  length           = 20
+  lower            = true
+  numeric          = true
+  special          = true
+  override_special = "-_*/"
+  min_special      = 3
+}
+
+resource "kubernetes_secret" "client_database_credentials" {
+  count = length(var.clients)
+  metadata {
+    name      = "credentials-${var.clients[count.index].user}"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = var.clients[count.index].namespace
+    }
+  }
+
+  data = {
+    "username" = var.clients[count.index].user
+    "password" = random_password.client_password[count.index].result
+  }
+
+  type = "kubernetes.io/basic-auth"
+}

--- a/modules/cnpg/variables.tf
+++ b/modules/cnpg/variables.tf
@@ -99,3 +99,21 @@ variable "clients" {
   }
 }
 
+# --------------- CLUSTER VARIABLES VARIABLES --------------- #
+variable "postgres_user_minio_configuration" {
+  description = "MinIO Configuration for storing PITR Backups"
+  type        = string
+  nullable    = false
+}
+
+variable "cluster_name" {
+  description = "Name of the PostgreSQL Database Cluster to be created"
+  type        = string
+  default     = "postgresql-cluster"
+}
+
+variable "backup_bucket_name" {
+  description = "Name of the bucket for storing PITR Backups in MinIO"
+  type        = string
+  nullable    = false
+}

--- a/modules/cnpg/variables.tf
+++ b/modules/cnpg/variables.tf
@@ -1,0 +1,26 @@
+# --------------- GENERAL VARIABLES --------------- #
+variable "app_name" {
+  description = "App name for deploying PostgreSQL Database"
+  type        = string
+  default     = "postgres"
+}
+
+variable "organization_name" {
+  description = "Organization name for deploying PostgreSQL Database"
+  type        = string
+  default     = "cloud"
+}
+
+variable "country_name" {
+  description = "Country name for deploying PostgreSQL Database"
+  type        = string
+  default     = "India"
+}
+
+# --------------- NAMESPACE VARIABLES --------------- #
+variable "namespace" {
+  description = "Namespace to be used for deploying PostgreSQL Database"
+  type        = string
+  default     = "postgres"
+}
+

--- a/modules/cnpg/variables.tf
+++ b/modules/cnpg/variables.tf
@@ -24,3 +24,58 @@ variable "namespace" {
   default     = "postgres"
 }
 
+variable "minio_namespace" {
+  description = "Namespace for the MinIO Deployment for storing PITR Backups"
+  type        = string
+  nullable    = false
+}
+
+# --------------- CERTIFICATE VARIABLES --------------- #
+variable "minio_certificate_authority" {
+  description = "Name of the Certificate Authority associated with the MinIO Storage Solution"
+  type        = string
+  nullable    = false
+}
+
+variable "cluster_issuer_name" {
+  description = "Name for the Cluster Issuer to be used to generate internal self signed certificates"
+  type        = string
+  nullable    = false
+}
+
+variable "server_certificate_authority_name" {
+  description = "Name of the Certificate Authority to be used with PostgreSQL Server"
+  type        = string
+  default     = "postgresql-server-certificate-authority"
+}
+
+variable "server_issuer_name" {
+  description = "Name of the Issuer to be used with PostgreSQL Server"
+  type        = string
+  default     = "postgresql-server-issuer"
+}
+
+variable "server_certificate_name" {
+  description = "Name of the Certificate to be used with PostgreSQL Server"
+  type        = string
+  default     = "postgresql-server-certificate"
+}
+
+variable "client_certificate_authority_name" {
+  description = "Name of the Certificate Authority to be used with PostgreSQL Client"
+  type        = string
+  default     = "postgresql-client-certificate-authority"
+}
+
+variable "client_issuer_name" {
+  description = "Name of the Issuer to be used with PostgreSQL Client"
+  type        = string
+  default     = "postgresql-client-issuer"
+}
+
+variable "client_streaming_replica_certificate_name" {
+  description = "Name of the Certificate to be used with PostgreSQL Streaming Replica Client"
+  type        = string
+  default     = "postgresql-streaming-replica-client-certificate"
+}
+

--- a/modules/cnpg/variables.tf
+++ b/modules/cnpg/variables.tf
@@ -79,3 +79,23 @@ variable "client_streaming_replica_certificate_name" {
   default     = "postgresql-streaming-replica-client-certificate"
 }
 
+# --------------- USER CONFIGURATION VARIABLES --------------- #
+variable "clients" {
+  description = "Object List of clients who need databases and users to be configured for"
+  type = list(object({
+    namespace          = string
+    user               = string
+    database           = string
+    derRequired        = bool
+    privateKeyEncoding = string
+  }))
+  default = []
+  validation {
+    condition = length([
+      for object in var.clients : true
+      if contains(["PKCS1", "PKCS8"], object.privateKeyEncoding)
+    ]) == length(var.clients)
+    error_message = "Encoding Value is either PKCS1 or PKCS8"
+  }
+}
+

--- a/modules/helm/cnpg.tf
+++ b/modules/helm/cnpg.tf
@@ -1,0 +1,9 @@
+// Cloud Native PG Operator Configuration
+resource "helm_release" "cnpg" {
+  name             = var.cnpg_configuration.name
+  namespace        = var.cnpg_configuration.namespace
+  repository       = var.cnpg_configuration.repository
+  chart            = var.cnpg_configuration.chart
+  version          = var.cnpg_configuration.version
+  create_namespace = var.cnpg_configuration.create_namespace
+}

--- a/modules/helm/variables.tf
+++ b/modules/helm/variables.tf
@@ -56,3 +56,16 @@ variable "minio_operator_configuration" {
   }
 }
 
+# --------------- CLOUDNATIVE PG OPERATOR VARIABLES --------------- #
+variable "cnpg_configuration" {
+  description = "Dictionary filled with Cloud Native PG Operator Configuration Details"
+  type        = map(string)
+  default = {
+    "name"             = "cnpg"
+    "namespace"        = "cnpg-system"
+    "repository"       = "https://cloudnative-pg.github.io/charts"
+    "chart"            = "cloudnative-pg"
+    "version"          = "v0.23.2"
+    "create_namespace" = true
+  }
+}

--- a/modules/minio/certificates.tf
+++ b/modules/minio/certificates.tf
@@ -79,6 +79,12 @@ resource "kubernetes_manifest" "issuer" {
       status = "True"
     }
   }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 // Internal Certificate for MinIO Tenant Cluster
@@ -250,6 +256,12 @@ resource "kubernetes_manifest" "ingress_certificate" {
       status = "True"
     }
   }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 # Certificate to be used for MinIO API Ingress
@@ -294,5 +306,11 @@ resource "kubernetes_manifest" "api_ingress_certificate" {
       type   = "Ready"
       status = "True"
     }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }

--- a/modules/minio/certificates.tf
+++ b/modules/minio/certificates.tf
@@ -176,7 +176,7 @@ resource "kubernetes_manifest" "public_issuer" {
     "spec" = {
       "acme" = {
         "email"  = var.cloudflare_email
-        "server" = "https://acme-v02.api.letsencrypt.org/directory"
+        "server" = var.acme_server
         "privateKeySecretRef" = {
           "name" = var.cloudflare_issuer_name
         }

--- a/modules/minio/certificates.tf
+++ b/modules/minio/certificates.tf
@@ -45,6 +45,12 @@ resource "kubernetes_manifest" "certificate_authority" {
       status = "True"
     }
   }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 // Issuer for the MinIO Tenant Cluster
@@ -123,6 +129,11 @@ resource "kubernetes_manifest" "internal_certificate" {
       status = "True"
     }
   }
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 // Kubernetes Secret for Cloudflare Tokens
@@ -187,6 +198,12 @@ resource "kubernetes_manifest" "public_issuer" {
       type   = "Ready"
       status = "True"
     }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 

--- a/modules/minio/ingress.tf
+++ b/modules/minio/ingress.tf
@@ -74,9 +74,9 @@ resource "kubernetes_ingress_v1" "api_ingress" {
           path = "/"
           backend {
             service {
-              name = "minio"
+              name = "minio-hl"
               port {
-                number = 443
+                number = 9000
               }
             }
           }

--- a/modules/minio/outputs.tf
+++ b/modules/minio/outputs.tf
@@ -1,0 +1,19 @@
+output "namespace" {
+  description = "Namespace where MinIO is deployed"
+  value       = kubernetes_namespace.namespace.metadata[0].name
+}
+
+output "certificate-authority-name" {
+  description = "Certificate Authority Name for the MinIO Tenant"
+  value       = kubernetes_manifest.certificate_authority.manifest.spec.secretName
+}
+
+output "postgres-user-minio-configuration" {
+  description = "PostgreSQL Configuration for storing PITR backups"
+  value       = kubernetes_secret.postgres_user_configuration.metadata[0].name
+}
+
+output "postgres-backup-bucket" {
+  description = "Bucket to be used for storing PostgreSQL PITR Backups"
+  value       = var.postgresql_backup_bucket
+}

--- a/modules/minio/tenant.tf
+++ b/modules/minio/tenant.tf
@@ -1,6 +1,6 @@
 locals {
   users   = [for secret in concat(kubernetes_secret.user_configuration, [kubernetes_secret.postgres_user_configuration]) : { "name" : secret.metadata[0].name }]
-  buckets = [for bucket in concat(var.buckets, ["postgres"]) : { "name" : bucket }]
+  buckets = [for bucket in concat(var.buckets, [var.postgresql_backup_bucket]) : { "name" : bucket }]
 }
 
 resource "kubernetes_manifest" "minio_tenant" {

--- a/modules/minio/variables.tf
+++ b/modules/minio/variables.tf
@@ -154,6 +154,12 @@ variable "users" {
   default     = []
 }
 
+variable "postgresql_backup_bucket" {
+  description = "Bucket to be used for storing PostgreSQL PITR Backups"
+  type        = string
+  default     = "postgres"
+}
+
 variable "buckets" {
   description = "List of buckets for which MinIO Tenant needs to be deployed with"
   type        = list(string)

--- a/modules/minio/variables.tf
+++ b/modules/minio/variables.tf
@@ -92,6 +92,12 @@ variable "cloudflare_issuer_name" {
   default     = "minio-cloudflare-issuer"
 }
 
+variable "acme_server" {
+  description = "URL for the ACME Server to be used, defaults to production URL for LetsEncrypt"
+  type        = string
+  default     = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
 variable "ingress_certificate_name" {
   description = "Name of the Ingress Certificate to be associated with MinIO Storage Solution"
   type        = string


### PR DESCRIPTION
# Changes:
 - Migrate PostgreSQL Deployment to OpenTofu Modules for an SQL Database Solution
 - Utilizing credentials which were generated on startup for MinIO instead of generating extra access keys
 - Added configurable list of clients for generating credentials, certificates (and their replications) and databases
 - Upgraded to the latest Operator for more control over resources