### PR TITLE
Migration of Keycloak Deployment to OpenTofu Modules for an Identity Platform solution

### DIFF
--- a/modules/cnpg/outputs.tf
+++ b/modules/cnpg/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace where the PostgreSQL Database is deployed in"
+  value       = kubernetes_namespace.namespace.metadata[0].name
+}
+
+output "server-certificate-authority" {
+  description = "Certificate Authority being used with PostgreSQL Database"
+  value       = kubernetes_manifest.server_certificate_authority.manifest.spec.secretName
+}

--- a/modules/keycloak/certificates.tf
+++ b/modules/keycloak/certificates.tf
@@ -1,0 +1,309 @@
+// Database Certificate Authority to be used for database connections
+resource "kubernetes_secret" "database_server_certificate_authority" {
+  metadata {
+    name      = var.database_server_certificate_authority_name
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflects" = "${var.postgres_namespace}/${var.database_server_certificate_authority_name}"
+    }
+  }
+
+  data = {
+    "ca.crt"  = ""
+    "tls.crt" = ""
+    "tls.key" = ""
+  }
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+// Database Client Certificate to be used for database connections
+resource "kubernetes_secret" "database_client_certificate" {
+  metadata {
+    name      = var.database_client_certificate_name
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflects" = "${var.postgres_namespace}/${var.database_client_certificate_name}"
+    }
+  }
+
+  data = {
+    "ca.crt"  = ""
+    "tls.crt" = ""
+    "tls.key" = ""
+    "key.der" = ""
+  }
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+// Certificate Authority to be used with Keycloak Cluster
+resource "kubernetes_manifest" "certificate_authority" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.certificate_authority_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "certificate-authority"
+      }
+    }
+    "spec" = {
+      "isCA" = true
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = [var.app_name]
+      }
+      "commonName" = var.certificate_authority_name
+      "secretName" = var.certificate_authority_name
+      "duration"   = "70128h"
+      "privateKey" = {
+        "algorithm" = "ECDSA"
+        "size"      = 256
+      }
+      "issuerRef" = {
+        "name"  = "${var.cluster_issuer_name}"
+        "kind"  = "ClusterIssuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Issuer for the Keycloak Cluster
+resource "kubernetes_manifest" "issuer" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Issuer"
+    "metadata" = {
+      "name"      = var.issuer_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "issuer"
+      }
+    }
+    "spec" = {
+      "ca" = {
+        "secretName" = kubernetes_manifest.certificate_authority.manifest.spec.secretName
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Internal Certificate for Keycloak Cluster
+resource "kubernetes_manifest" "internal_certificate" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.internal_certificate_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "internal-certificate"
+      }
+    }
+    "spec" = {
+      "dnsNames" = [
+        "${var.host_name}.${var.domain}",
+        "localhost",
+        "127.0.0.1",
+        "*.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local",
+        "keycloak-cluster-service",
+        "keycloak-cluster-service.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local",
+        "*.keycloak-cluster-service.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local",
+        "keycloak-cluster-discovery",
+        "keycloak-cluster-discovery.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local",
+        "*.keycloak-cluster-discovery.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local",
+      ]
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = [var.app_name]
+      }
+      "commonName" = var.internal_certificate_name
+      "secretName" = var.internal_certificate_name
+      "issuerRef" = {
+        "name" = kubernetes_manifest.issuer.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Kubernetes Secret for Cloudflare Tokens
+resource "kubernetes_secret" "cloudflare_token" {
+  metadata {
+    name      = "cloudflare-token"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      "app"       = var.app_name
+      "component" = "secret"
+    }
+  }
+
+  data = {
+    cloudflare-token = var.cloudflare_token
+  }
+
+  type = "Opaque"
+}
+
+// Cloudflare Issuer for Keycloak Ingress Service
+resource "kubernetes_manifest" "public_issuer" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Issuer"
+    "metadata" = {
+      "name"      = var.cloudflare_issuer_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "cloudflare-issuer"
+      }
+    }
+    "spec" = {
+      "acme" = {
+        "email"  = var.cloudflare_email
+        "server" = var.acme_server
+        "privateKeySecretRef" = {
+          "name" = var.cloudflare_issuer_name
+        }
+        "solvers" = [
+          {
+            "dns01" = {
+              "cloudflare" = {
+                "email" = var.cloudflare_email
+                "apiTokenSecretRef" = {
+                  "name" = "cloudflare-token"
+                  "key"  = "cloudflare-token"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  depends_on = [kubernetes_secret.cloudflare_token]
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Certificate to be used for Keycloak Ingress
+resource "kubernetes_manifest" "ingress_certificate" {
+
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.ingress_certificate_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "ingress-certificate"
+      }
+    }
+    "spec" = {
+      "duration"    = "2160h"
+      "renewBefore" = "360h"
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = [var.app_name]
+      }
+      "privateKey" = {
+        "algorithm" = "RSA"
+        "encoding"  = "PKCS1"
+        "size"      = "2048"
+      }
+      "dnsNames"   = ["${var.host_name}.${var.domain}"]
+      "secretName" = var.ingress_certificate_name
+      "issuerRef" = {
+        "name"  = kubernetes_manifest.public_issuer.manifest.metadata.name
+        "kind"  = "Issuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}

--- a/modules/keycloak/configmap.tf
+++ b/modules/keycloak/configmap.tf
@@ -1,0 +1,15 @@
+# Realm JSON File to be used for setting up the Keycloak Clients
+resource "kubernetes_config_map" "realm_configuration" {
+  metadata {
+    name      = "realm-configuration"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "configmap"
+    }
+  }
+
+  data = {
+    "realm.json" = "${file("${path.module}/realm.json")}"
+  }
+}

--- a/modules/keycloak/deployment.tf
+++ b/modules/keycloak/deployment.tf
@@ -1,0 +1,225 @@
+// Keycloak Stateful Set Cluster
+resource "kubernetes_stateful_set" "keycloak_cluster" {
+  metadata {
+    name      = "keycloak-cluster"
+    namespace = var.namespace
+    labels = {
+      app       = "keycloak"
+      component = "statefulset"
+    }
+  }
+  spec {
+    replicas     = 1
+    service_name = ""
+
+    // Stateful Set Pod Selector
+    selector {
+      match_labels = {
+        app       = "keycloak"
+        component = "pod"
+      }
+    }
+
+    // Pod Template
+    template {
+
+      // Pod Metadata
+      metadata {
+        labels = {
+          app       = "keycloak"
+          component = "pod"
+        }
+      }
+
+      // Pod Spec
+      spec {
+
+        // Container Details
+        container {
+          name  = "keycloak"
+          image = "quay.io/keycloak/keycloak:26.0.7"
+          args  = ["-Djgroups.dns.query=keycloak-discovery.keycloak", "--verbose", "start", "--import-realm"]
+
+          // Environment Variables
+          env {
+            name  = "KC_HOSTNAME"
+            value = "${var.host_name}.${var.domain}"
+          }
+
+          dynamic "env" {
+            for_each = var.keycloak_environment_variables
+            content {
+              name  = env.value["name"]
+              value = env.value["value"]
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = kubernetes_secret.keycloak_credentials.metadata[0].name
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = kubernetes_secret.realm_secrets.metadata[0].name
+            }
+          }
+
+          env {
+            name  = "KC_DB"
+            value = "postgres"
+          }
+
+          env {
+            name = "KC_DB_USERNAME"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.database_credentials.metadata[0].name
+                key  = "username"
+              }
+            }
+          }
+
+          env {
+            name = "KC_DB_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.database_credentials.metadata[0].name
+                key  = "password"
+              }
+            }
+          }
+
+          // Port Mappings
+          dynamic "port" {
+            for_each = var.keycloak_ports
+            content {
+              name           = port.value["name"]
+              container_port = port.value["containerPort"]
+              protocol       = port.value["protocol"]
+            }
+          }
+
+          // Startup, Liveness and Readiness Probes
+          startup_probe {
+            failure_threshold = 3
+            http_get {
+              path   = "/health/started"
+              port   = "management"
+              scheme = "HTTPS"
+            }
+            period_seconds        = 10
+            success_threshold     = 1
+            timeout_seconds       = 10
+            initial_delay_seconds = 60
+          }
+
+          readiness_probe {
+            failure_threshold = 3
+            http_get {
+              path   = "/health/ready"
+              port   = "management"
+              scheme = "HTTPS"
+            }
+            period_seconds        = 10
+            success_threshold     = 1
+            timeout_seconds       = 10
+            initial_delay_seconds = 60
+          }
+
+          liveness_probe {
+            failure_threshold = 3
+            http_get {
+              path   = "/health/live"
+              port   = "management"
+              scheme = "HTTPS"
+            }
+            period_seconds        = 10
+            success_threshold     = 1
+            timeout_seconds       = 10
+            initial_delay_seconds = 60
+          }
+
+          // Resource limitations
+          resources {
+            requests = {
+              "cpu"    = "500m"
+              "memory" = "1Gi"
+            }
+
+            limits = {
+              "cpu"    = "500m"
+              "memory" = "1Gi"
+            }
+          }
+
+          // Volume mounts
+          volume_mount {
+            name       = kubernetes_secret.database_server_certificate_authority.metadata[0].name
+            mount_path = "/mnt/certs/database/certificate-authority"
+          }
+
+          volume_mount {
+            name       = kubernetes_secret.database_client_certificate.metadata[0].name
+            mount_path = "/mnt/certs/database/certificate"
+          }
+
+          volume_mount {
+            name       = kubernetes_manifest.internal_certificate.manifest.spec.secretName
+            mount_path = "/mnt/certs/tls"
+          }
+
+          volume_mount {
+            name       = kubernetes_config_map.realm_configuration.metadata[0].name
+            mount_path = "/opt/keycloak/data/import"
+          }
+        }
+
+        // Volumes
+        volume {
+          name = kubernetes_secret.database_server_certificate_authority.metadata[0].name
+          secret {
+            secret_name = kubernetes_secret.database_server_certificate_authority.metadata[0].name
+          }
+        }
+
+        volume {
+          name = kubernetes_secret.database_client_certificate.metadata[0].name
+          secret {
+            secret_name = kubernetes_secret.database_client_certificate.metadata[0].name
+          }
+        }
+
+        volume {
+          name = kubernetes_manifest.internal_certificate.manifest.spec.secretName
+          secret {
+            secret_name = kubernetes_manifest.internal_certificate.manifest.spec.secretName
+          }
+        }
+
+        volume {
+          name = kubernetes_config_map.realm_configuration.metadata[0].name
+          config_map {
+            name = kubernetes_config_map.realm_configuration.metadata[0].name
+          }
+        }
+
+        security_context {
+          fs_group    = 1000
+          run_as_user = 1000
+        }
+
+      }
+    }
+
+    update_strategy {
+      rolling_update {
+        partition = 0
+      }
+      type = "RollingUpdate"
+    }
+  }
+
+  depends_on = [kubernetes_service.keycloak_service, kubernetes_service.keycloak_discovery]
+}

--- a/modules/keycloak/ingress.tf
+++ b/modules/keycloak/ingress.tf
@@ -1,0 +1,43 @@
+# Ingress for accessing the Keycloak Cluster
+resource "kubernetes_ingress_v1" "ingress" {
+  metadata {
+    name      = "ingress"
+    namespace = var.namespace
+    labels = {
+      app       = var.app_name
+      component = "ingress"
+    }
+    annotations = {
+      "nginx.ingress.kubernetes.io/proxy-ssl-verify" : "on"
+      "nginx.ingress.kubernetes.io/proxy-ssl-secret" : "${kubernetes_namespace.namespace.metadata[0].name}/${kubernetes_manifest.internal_certificate.manifest.spec.secretName}"
+      "nginx.ingress.kubernetes.io/proxy-ssl-name" : "${kubernetes_service.keycloak_service.metadata[0].name}.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local"
+      "nginx.ingress.kubernetes.io/backend-protocol" : "HTTPS"
+      "nginx.ingress.kubernetes.io/rewrite-target" : "/"
+      "nginx.ingress.kubernetes.io/proxy-body-size" : 0
+    }
+  }
+
+  spec {
+    ingress_class_name = "nginx"
+    tls {
+      hosts       = ["${var.host_name}.${var.domain}"]
+      secret_name = kubernetes_manifest.ingress_certificate.manifest.spec.secretName
+    }
+    rule {
+      host = "${var.host_name}.${var.domain}"
+      http {
+        path {
+          path = "/"
+          backend {
+            service {
+              name = kubernetes_service.keycloak_service.metadata[0].name
+              port {
+                number = 8443
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/keycloak/namespace.tf
+++ b/modules/keycloak/namespace.tf
@@ -1,0 +1,10 @@
+// Namespace configuration for Keycloak Identity Platform solution
+resource "kubernetes_namespace" "namespace" {
+  metadata {
+    name = var.namespace
+    labels = {
+      app       = var.app_name
+      component = "namespace"
+    }
+  }
+}

--- a/modules/keycloak/realm.json
+++ b/modules/keycloak/realm.json
@@ -1,0 +1,2564 @@
+{
+  "id": "e1ef68f2-9a26-4b56-aa20-9f7d8abd680b",
+  "realm": "${APPLICATION_NAME}",
+  "displayName": "",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 3600,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 3600,
+  "clientSessionMaxLifespan": 36000,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": true,
+  "rememberMe": true,
+  "verifyEmail": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "a0c97e4f-14ce-489d-b74a-0318eef470d9",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "e1ef68f2-9a26-4b56-aa20-9f7d8abd680b",
+        "attributes": {}
+      },
+      {
+        "id": "eb1db98a-594a-42ef-9178-588fbc4606dc",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "e1ef68f2-9a26-4b56-aa20-9f7d8abd680b",
+        "attributes": {}
+      },
+      {
+        "id": "b2345952-4b7d-41cf-b783-810bb965eec0",
+        "name": "default-roles-${APPLICATION_NAME}",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "e1ef68f2-9a26-4b56-aa20-9f7d8abd680b",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "4b05619c-8ea5-445c-9f4d-27170a5cc024",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "view-identity-providers",
+                "manage-users",
+                "view-clients",
+                "query-clients",
+                "manage-clients",
+                "manage-authorization",
+                "impersonation",
+                "manage-events",
+                "query-groups",
+                "manage-identity-providers",
+                "create-client",
+                "view-users",
+                "query-users",
+                "query-realms",
+                "view-realm",
+                "view-authorization",
+                "view-events",
+                "manage-realm"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "1d82c1da-cccb-4a29-a73b-f1fafe0e520f",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "455acde1-4019-4745-9c37-e1302084d70e",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "49df4010-1e2f-43d5-8838-12678da8a911",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "5ffcc52d-6ef2-4a99-bb92-adceff6cf8d9",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "01793df8-b206-450c-b219-2e01b3d5926b",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "4ac510b5-7cce-49dd-893c-9f8a708bda74",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "d3d3b11c-9371-4c74-be95-e4a231ec00fe",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "08531ae9-a003-4af1-bb7c-9dd5a414f28a",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "a61588ee-e64b-4b8e-8a3a-f8358d3e93a8",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "52192ba7-2c91-441a-b99f-6ed213d92172",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "d1f2f33d-f856-4599-b072-0c8c17676a24",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "6d60bee5-aa09-4c34-985b-d837b24e838b",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "05aa9052-f0f4-48cd-82ed-03e8a86f5770",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "017c86b9-719d-4aa9-b21f-92c92aa38eaf",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "c8c67e17-0b74-458e-ae4c-69005d73f4e3",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "df5ab5cb-1750-4f3b-aa0a-638ef25f9c59",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "4e5278dc-1b83-406a-a83d-1e24476a2b7f",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        },
+        {
+          "id": "ea91f40c-ab16-477f-9b01-a0d7716de89a",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+          "attributes": {}
+        }
+      ],
+      "${APPLICATION_NAME}-frontend": [],
+      "${APPLICATION_NAME}-tester": [],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "448ee36d-b3ab-4d9e-abcc-d305c66b9268",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "093d974e-f937-41d5-a6cb-94c68a53fbc7",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "5f3474d5-f591-4f2e-8124-62c860e1307d",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "ce786998-2ecc-49af-9c8f-6164aee3cc85",
+          "name": "view-${APPLICATION_NAME}s",
+          "description": "${role_view-${APPLICATION_NAME}s}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "9ca8bfbc-e3ed-4723-a522-b03ab3b59b0c",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "031c32f8-32e4-42cf-af44-0596b6f5e9a3",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "da69d4c2-db5c-4c13-bbbd-f266239199da",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "b31acb06-e533-4122-adf5-d72b4ff9df22",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "90970263-b57a-4089-a371-d506245941ed",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        },
+        {
+          "id": "2ee6e61a-cec6-4807-b1c2-e118c87145ea",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "b2345952-4b7d-41cf-b783-810bb965eec0",
+    "name": "default-roles-${APPLICATION_NAME}",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "e1ef68f2-9a26-4b56-aa20-9f7d8abd680b"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "4c5e2da0-07c8-431a-9ac4-4bcc5377e75a",
+      "username": "service-account-${APPLICATION_NAME}-tester",
+      "emailVerified": false,
+      "createdTimestamp": 1741712671847,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "${APPLICATION_NAME}-tester",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-${APPLICATION_NAME}"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "dce27bed-f903-4a9e-af21-b1e8198326ce",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/${APPLICATION_NAME}/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/${APPLICATION_NAME}/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "e6035a31-ac14-4c26-a346-8cae4f8d58c5",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/${APPLICATION_NAME}/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/${APPLICATION_NAME}/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "8ac2515d-15e2-40fe-b4fc-d22f157e3a73",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b356f877-f60e-4325-a454-c78665782fd7",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "9b5d999c-7f12-4bac-8ba8-c592c5b118c1",
+      "clientId": "${APPLICATION_NAME}-frontend",
+      "name": "${APPLICATION_NAME} Frontend",
+      "description": "Client for Frontend Authentication",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "http://localhost:5173",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:5173/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5173"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "client.introspection.response.allow.jwt.claim.enabled": "false",
+        "post.logout.redirect.uris": "http://localhost:5173/",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.use.lightweight.access.token.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "acr.loa.map": "{}",
+        "require.pushed.authorization.requests": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "display.on.consent.screen": "false",
+        "pkce.code.challenge.method": "S256",
+        "token.response.type.bearer.lower-case": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "bdb69e73-94d0-4144-b0bc-d246734abd99",
+      "clientId": "${APPLICATION_NAME}-tester",
+      "name": "${APPLICATION_NAME} Tester",
+      "description": "Client of generating JWT Tokens to test against secured APIs",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "${TESTER_SECRET}",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1741712671",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "42e19cba-68ec-4f37-bbc6-48cbf1796608",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "938ab2b5-8385-46a3-8598-367ea5621453",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "31960cab-ac95-4cca-beb0-33152c67f0de",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "093d974e-f937-41d5-a6cb-94c68a53fbc7",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2b5558a2-af01-4cc8-8a98-4cd4b73bd2dd",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ce91a0a8-5035-4e82-a7ef-35af144b9307",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/${APPLICATION_NAME}/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/${APPLICATION_NAME}/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "42de0ba3-ce8b-4d13-8140-910f0c5dad3d",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "fdd58031-7478-4cf5-962d-4871b765dd79",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "2b3f35b0-6851-4107-8bc1-60e3d217f884",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "50186911-629c-41dc-b4ee-0c7f6093447b",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "d325c030-aad4-4fdb-a887-f67118cb7f00",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8ab39344-048b-405c-b6e5-f6d409603031",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5c7e5b20-c76f-403b-b107-0caff7983838",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "34a5153c-0709-4664-92d0-c3039bae9c57",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "572abb7a-b704-468c-8704-abd133fb0bee",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "85fd5ff6-fb75-4c4c-b18c-774885597767",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5a468957-7843-41e4-aaac-2a790bdb4343",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0d6ae467-c461-4296-8bd1-3dece87128cb",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5c7f1845-8418-4297-bdd2-e285e246598e",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4fd4abf2-5301-499e-ac45-90488e2e8a48",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "d6d2c694-b621-40b3-b774-bc082d6cdd20",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "efc4e2bd-1276-4090-ab3a-47cc98f4ea77",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d7f99aa2-ad09-47d1-953c-f70752e0fca4",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "de84b979-aa00-427b-82db-5ac83832966e",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e4956e93-05eb-4a21-94eb-ae0e0c66da91",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6af91ee6-2dc1-4b15-8622-ceccad5d21fd",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f70178d1-a68d-4c91-bd8c-7d1b100207b8",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "ec8ceecd-4860-44e0-ace6-30881c4e3bf9",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "696a62f0-f5c9-4e16-9c37-e02e30b5e76d",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "350bba8d-ac3d-46eb-9570-2d7a9dec819d",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9eb3c91d-5174-4bca-9cff-9e152efed96d",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "02b18ade-62d7-42dd-b087-aae9d9e3986a",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f3cc697f-3674-4acd-b381-ff865fc7f5cb",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6360c552-26c7-462f-8a59-03336bde4d2d",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "00900529-637c-4951-a4cf-060d9c59ecbe",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c31695dd-0d55-41a5-8365-427a48dcbecb",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "1cab7277-3b97-4e6d-96af-222ea9c2d3ad",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "99d71596-8270-4af1-8872-e95f832ffd63",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "aa955fcb-1293-479d-bd5e-ad56e6999fa7",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3e88a69d-83e2-4c91-a210-5984ef490450",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "db59540b-759d-489f-aa68-e2dac00693a1",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "105eeb56-6ace-434e-9bb3-28b99d255005",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "dbadf569-5e3f-4b5b-82dc-f09acaf4e919",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "4ef0665a-0a5e-42cd-a99c-64549e16d70b",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "ea08cc5a-3e80-40e9-b41a-94e018907446",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "285ae66d-9f87-46a3-8d99-c3b65efd13a9",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "dd737425-31a1-4d54-b7cc-d8214246a3ef",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "d21d88f4-924b-400b-921f-5d6f7c05ab8c",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "909eca64-94a3-4071-af00-2e065cf22b53",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "1504ee1d-8531-4429-9927-7875d24aecb9",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "20f43e4c-140d-48ee-bc99-56f4523570bf",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {
+    "password": "${SMTP_PASSWORD}",
+    "replyToDisplayName": "",
+    "starttls": "true",
+    "auth": "true",
+    "port": " ${SMTP_PORT}",
+    "host": "${SMTP_HOST}",
+    "replyTo": "",
+    "from": "${SMTP_MAIL}",
+    "fromDisplayName": "${APPLICATION_NAME}",
+    "envelopeFrom": "",
+    "ssl": "true",
+    "user": "${SMTP_USERNAME}"
+  },
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "871ffe50-35da-4884-a739-7531174b61f6",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-property-mapper",
+            "saml-role-list-mapper",
+            "saml-user-property-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "bc6cf1c2-ffff-42aa-9231-3d3f9f635c0f",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "bf3a9d67-17ae-442f-a9b1-be8d0f2044fa",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0326dc77-15e1-4923-b796-c99ce9ee5021",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "799d3d26-63fd-4361-b829-dd38f3811df2",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "58595d95-99c7-4c9a-999b-e17c65d36833",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "ed518844-7743-461d-9cd5-cb5436b3fa52",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "63c35a20-6d9d-4ce3-a41c-300b8ecc8456",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "63ad3af9-dec3-4540-8c01-2cb1c1a7df31",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "e864b29a-f8b2-41f8-b865-da28b913168f",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "905c363b-5ab8-43f8-a942-ecfe3280e37c",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "1f32c3c0-90cf-4976-952e-827ff91d31cc",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "6b9c41d5-3e71-4667-8bd8-de98a774f93e",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "3f76e2bd-3e0c-4b5d-87c9-871e4551810f",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "5fb577b1-d6e0-4918-9797-53ba9b5519d9",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "97b687fb-bee9-46c9-a023-270a6c6ca15d",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "62477f12-8db2-437c-91db-b781475963ae",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "9f5712c4-e111-4d06-89e9-71687ed8b5d6",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cf75d8c0-70d4-4d1d-b39a-3bf1b198e3e8",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "381c7f9c-f0e7-4d20-9b3b-e298fd0fc406",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a36b8b68-f96c-4e7b-b417-0235b59e9c2a",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f87cdf3e-2716-488a-b056-cb3dd0965a65",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b70f023c-99bb-4c88-8841-fc8630faa178",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "888f466b-9ecf-46f6-a5a6-3a7fde9a7802",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "3315f88b-6a8b-4332-9cc2-433e65c7c791",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f664ab8d-3b56-46ec-a629-69168e2d2206",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "6c1fcb2e-6029-43cc-a821-16227762d000",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "fe8b6b49-2f49-4d6d-9a4d-f5da7cdd4696",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8f9f8b1e-4540-4180-b659-0543c5f6774c",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "06524cb8-6fb2-4f19-8756-d9be67c1f174",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1870cba8-a29d-463b-bf5c-2131f0f7e82a",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e11328ec-d1fa-4905-af2b-9964530a9eab",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e1c0db3a-3669-4043-ab9b-6041e7c773fb",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "412a9242-2d57-4587-8331-586e7733e6a2",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "c9393810-c267-461d-8409-3fd793959e81",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "3600",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "36000",
+    "frontendUrl": "",
+    "organizationsEnabled": "false",
+    "acr.loa.map": "{}"
+  },
+  "keycloakVersion": "26.0.7",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/modules/keycloak/secrets.tf
+++ b/modules/keycloak/secrets.tf
@@ -1,0 +1,89 @@
+// Database Credentials to connect to the PostgreSQL Database
+resource "kubernetes_secret" "database_credentials" {
+  metadata {
+    name      = var.database_credentials
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflects" = "${var.postgres_namespace}/${var.database_credentials}"
+    }
+
+
+  }
+
+  data = {
+    username = ""
+    password = ""
+  }
+
+  type = "Opaque"
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+// Keycloak Credentials
+resource "random_password" "keycloak_password" {
+  length           = 20
+  lower            = true
+  numeric          = true
+  special          = true
+  override_special = "-_*/"
+  min_special      = 3
+}
+
+resource "kubernetes_secret" "keycloak_credentials" {
+  metadata {
+    name      = var.keycloak_credentials
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+  }
+
+  data = {
+    KC_BOOTSTRAP_ADMIN_USERNAME = "keycloak.admin"
+    KC_BOOTSTRAP_ADMIN_PASSWORD = random_password.keycloak_password.result
+  }
+
+  type = "Opaque"
+}
+
+# Keycloak Realm Configuration
+resource "random_password" "tester_password" {
+  length           = 20
+  lower            = true
+  numeric          = true
+  special          = true
+  override_special = "-_*/"
+  min_special      = 3
+}
+
+resource "kubernetes_secret" "realm_secrets" {
+  metadata {
+    name      = "realm-secrets"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+  }
+
+  data = {
+    APPLICATION_NAME = var.realm_settings["application_name"]
+    SMTP_HOST        = var.realm_settings["smtp_host"]
+    SMTP_PORT        = var.realm_settings["smtp_port"]
+    SMTP_MAIL        = var.realm_settings["smtp_mail"]
+    SMTP_USERNAME    = var.realm_settings["smtp_username"]
+    SMTP_PASSWORD    = var.realm_settings["smtp_password"]
+    TESTER_SECRET    = random_password.tester_password.result
+  }
+}

--- a/modules/keycloak/service.tf
+++ b/modules/keycloak/service.tf
@@ -1,0 +1,54 @@
+// Keycloak Discovery Service
+resource "kubernetes_service" "keycloak_discovery" {
+  metadata {
+    name      = "keycloak-discovery"
+    namespace = var.namespace
+  }
+
+  spec {
+    selector = {
+      app       = "keycloak"
+      component = "pod"
+    }
+    session_affinity = "None"
+    port {
+      name        = "discovery"
+      port        = 7800
+      target_port = "discovery"
+    }
+    type       = "ClusterIP"
+    cluster_ip = "None"
+  }
+}
+
+// Keycloak HTTP(S) and Management Service
+resource "kubernetes_service" "keycloak_service" {
+  metadata {
+    name      = "keycloak-cluster-service"
+    namespace = var.namespace
+  }
+
+  spec {
+    selector = {
+      app       = "keycloak"
+      component = "pod"
+    }
+    session_affinity = "None"
+    port {
+      name        = "http"
+      port        = 8080
+      target_port = "http"
+    }
+    port {
+      name        = "https"
+      port        = 8443
+      target_port = "https"
+    }
+    port {
+      name        = "management"
+      port        = 9000
+      target_port = "management"
+    }
+    type = "ClusterIP"
+  }
+}

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -1,0 +1,25 @@
+# --------------- GENERAL VARIABLES --------------- #
+variable "app_name" {
+  description = "App name for deploying Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak"
+}
+
+variable "organization_name" {
+  description = "Organization name for deploying Keycloak Identity Platform solution"
+  type        = string
+  default     = "cloud"
+}
+
+variable "country_name" {
+  description = "Country name for deploying Keycloak Identity Platform solution"
+  type        = string
+  default     = "India"
+}
+
+# --------------- NAMESPACE VARIABLES --------------- #
+variable "namespace" {
+  description = "Namespace to be used for deploying Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak"
+}

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -138,3 +138,91 @@ variable "realm_settings" {
   sensitive = true
 }
 
+# --------------- CLUSTER VARIABLES --------------- #
+
+variable "keycloak_environment_variables" {
+  default = [
+    {
+      name  = "KC_HTTP_PORT"
+      value = "8080"
+    },
+    {
+      name  = "KC_HTTPS_PORT"
+      value = "8443"
+    },
+    {
+      name  = "KC_HTTPS_CERTIFICATE_FILE"
+      value = "/mnt/certs/tls/tls.crt"
+    },
+    {
+      name  = "KC_HTTPS_CERTIFICATE_KEY_FILE"
+      value = "/mnt/certs/tls/tls.key"
+    },
+    {
+      name  = "KC_DB_URL"
+      value = "jdbc:postgresql://postgresql-cluster-rw.postgres.svc/keycloak?ssl=true&sslmode=verify-full&sslrootcert=/mnt/certs/database/certificate-authority/ca.crt&sslcert=/mnt/certs/database/certificate/tls.crt&sslkey=/mnt/certs/database/certificate/key.der"
+    },
+    {
+      name  = "KC_DB_POOL_INITIAL_SIZE"
+      value = "1"
+    },
+    {
+      name  = "KC_DB_POOL_MIN_SIZE"
+      value = "1"
+    },
+    {
+      name  = "KC_DB_POOL_MAX_SIZE"
+      value = "3"
+    },
+    {
+      name  = "KC_HEALTH_ENABLED"
+      value = "true"
+    },
+    {
+      name  = "KC_CACHE"
+      value = "ispn"
+    },
+    {
+      name  = "KC_CACHE_STACK"
+      value = "kubernetes"
+    },
+    {
+      name  = "KC_PROXY"
+      value = "passthrough"
+    },
+    {
+      name  = "KC_TRUSTSTORE_PATHS"
+      value = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    }
+  ]
+
+  description = "Environment variables for Keycloak Configuration"
+}
+
+variable "keycloak_ports" {
+  default = [
+
+    {
+      name          = "https"
+      containerPort = "8443"
+      protocol      = "TCP"
+    },
+    {
+      name          = "http"
+      containerPort = "8080"
+      protocol      = "TCP"
+    },
+    {
+      name          = "management"
+      containerPort = "9000"
+      protocol      = "TCP"
+    },
+    {
+      name          = "discovery"
+      containerPort = "7800"
+      protocol      = "TCP"
+    },
+  ]
+
+  description = "Keycloak Ports Configuration"
+}

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -110,3 +110,31 @@ variable "domain" {
   nullable    = false
 }
 
+# --------------- SECRET VARIABLES --------------- #
+
+variable "database_credentials" {
+  description = "Name of the secret which contains the database credentials for Keycloak"
+  type        = string
+  nullable    = false
+}
+
+variable "keycloak_credentials" {
+  description = "Name of the secret which contains the credentials for the Keycloak Cluster"
+  type        = string
+  default     = "default-credentials"
+}
+
+variable "realm_settings" {
+  description = "Realm Settings for pre-installing a realm with Keycloak"
+  type = object({
+    application_name = string
+    smtp_host        = string
+    smtp_port        = number
+    smtp_mail        = string
+    smtp_username    = string
+    smtp_password    = string
+  })
+  nullable  = false
+  sensitive = true
+}
+

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -23,3 +23,90 @@ variable "namespace" {
   type        = string
   default     = "keycloak"
 }
+
+variable "postgres_namespace" {
+  description = "Namespace for the PostgreSQL Deployment for database connections"
+  type        = string
+  nullable    = false
+}
+
+# --------------- DATABASE CERTIFICATE VARIABLES --------------- #
+variable "database_server_certificate_authority_name" {
+  description = "Server Certificate Authority being used for the database"
+  type        = string
+  nullable    = false
+}
+
+variable "database_client_certificate_name" {
+  description = "Client Certificate to be used for Keycloak User"
+  type        = string
+  nullable    = false
+}
+
+# --------------- CERTIFICATE VARIABLES --------------- #
+variable "cluster_issuer_name" {
+  description = "Name for the Cluster Issuer to be used to generate internal self signed certificates"
+  type        = string
+  nullable    = false
+}
+
+variable "certificate_authority_name" {
+  description = "Name of the Certificate Authority to be associated with Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak-certificate-authority"
+}
+
+variable "issuer_name" {
+  description = "Name of the Issuer to be associated with Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak-certificate-issuer"
+}
+
+variable "internal_certificate_name" {
+  description = "Name of the Internal Certificate to be associated with Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak-internal-certificate"
+}
+
+variable "cloudflare_token" {
+  description = "Token for generating Ingress Certificates to be associated with Keycloak Identity Platform solution"
+  type        = string
+  nullable    = false
+}
+
+variable "cloudflare_email" {
+  description = "Email for generating Ingress Certificates to be associated with Keycloak Identity Platform solution"
+  type        = string
+  nullable    = false
+}
+
+variable "cloudflare_issuer_name" {
+  description = "Name of the Cloudflare Issuer to be associated with Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak-cloudflare-issuer"
+}
+
+variable "acme_server" {
+  description = "URL for the ACME Server to be used, defaults to production URL for LetsEncrypt"
+  type        = string
+  default     = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
+variable "ingress_certificate_name" {
+  description = "Name of the Ingress Certificate to be associated with Keycloak Identity Platform solution"
+  type        = string
+  default     = "keycloak-ingress-certificate"
+}
+
+variable "host_name" {
+  description = "Host name for which Ingress Certificate is to be generated for"
+  type        = string
+  default     = "auth"
+}
+
+variable "domain" {
+  description = "Domain for which Ingress Certificate is to be generated for"
+  type        = string
+  nullable    = false
+}
+


### PR DESCRIPTION
# Changes:
 - Migration of Keycloak Deployment to OpenTofu Modules for an Identity Platform solution
 - Database credentials and certificates being replicated using Kubernetes Reflector
 - Default Credentials for Keycloak being provisioned with random password generator
 - Realm Configuration being done as well using secrets including SMTP credentials